### PR TITLE
to french regex

### DIFF
--- a/src/scenes/search/multiList.js
+++ b/src/scenes/search/multiList.js
@@ -3,6 +3,7 @@ import { ReactiveComponent } from "@appbaseio/reactivesearch";
 import { Input, Label, FormGroup, Collapse } from "reactstrap";
 import queryString from "query-string";
 import "./multiList.css";
+import { toFrenchRegex } from './utils';
 
 export default class MultiListUmbrellaUmbrella extends React.Component {
   state = {
@@ -134,7 +135,7 @@ class MultiListUmbrella extends React.Component {
       aggs: fields.reduce(
         (acc, field) => ({
           ...acc,
-          [field]: { terms: { field, include: `.*${search}.*`, ...sort, size } }
+          [field]: { terms: { field, include: `.*${toFrenchRegex(search)}.*`, ...sort, size } }
         }),
         {}
       )

--- a/src/scenes/search/utils.js
+++ b/src/scenes/search/utils.js
@@ -1,0 +1,19 @@
+// This function transforms a text to a french compatible regex.
+// So this:
+// "Voilà un château éloigné"
+// Turns to that:
+// "[Vv][oôöOÔÖ][iïîIÏÎ]l[àâäaÀÂÄA] [uùûüUÙÛÜ]n [cçÇC]h[àâäaÀÂÄA]t[éèêëeÉÈÊËE][àâäaÀÂÄA][uùûüUÙÛÜ] [éèêëeÉÈÊËE]l[oôöOÔÖ][iïîIÏÎ]gn[éèêëeÉÈÊËE]"
+// It works (TM).
+export function toFrenchRegex(text) {
+  return text
+    .replace(/[éèêëeÉÈÊËE]/g, "[éèêëeÉÈÊËE]")
+    .replace(/[àâäaÀÂÄA]/g, "[àâäaÀÂÄA]")
+    .replace(/[cçÇC]/g, "[cçÇC]")
+    .replace(/[iïîIÏÎ]/g, "[iïîIÏÎ]")
+    .replace(/[oôöOÔÖ]/g, "[oôöOÔÖ]")
+    .replace(/[uùûüUÙÛÜ]/g, "[uùûüUÙÛÜ]")
+    .replace(
+      /(^|[\s.\-,;!?])([a-zéèëê])/gi,
+      (v, w, x) => `${w}[${x.toUpperCase()}${x.toLowerCase()}]`
+    );
+}


### PR DESCRIPTION
@goffle J’ai trouvé un moyen de faire une recherche insensible à la casse et aux accents sur les facettes sans rien changer au modèle de données (donc pas besoin de changer les mappings d'elasticsearch tout de suite, même si on en aura besoin plein d'autres fois). 

C'est un peu _bidouille_ (quoique...), mais sur mes tests ça marche bien et ça répondra à 99% des cas (de toute façon en interne Elasticsearch fait ce genre de dégueulasseries pour les analyzers et les normalizers)