### PR TITLE
remove margin bottom

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,6 @@ html {
 }
 body {
   margin: 0;
-  margin-bottom: 60px;
   overflow: hidden;
   overflow-y: auto;
   font-family: "Open Sans", sans-serif;


### PR DESCRIPTION
Il y a une marge en bas qui fait est tout le temps présente (en blanc). Exemple : 

<img width="1439" alt="capture d ecran 2018-11-09 a 14 59 56" src="https://user-images.githubusercontent.com/1575946/48266604-27143900-e430-11e8-9afc-e7f271c260ae.png">

Je pense qu'elle n'apporte rien alors je la vire, mais je préfère faire une PR au cas-où tu me dis qu'elle était super importante pour une raison que je n'ai pas vue.