### PR TITLE
info about tiles

### DIFF
--- a/src/scenes/search/subComponents/Mosaique/Mosaique.js
+++ b/src/scenes/search/subComponents/Mosaique/Mosaique.js
@@ -10,10 +10,11 @@ export default ({ filter }) => (
       and: filter
     }}
     onResultStats={(total, took) => {
+      const info = "La mosaïque n'affiche par défaut que les notices avec image.";
       if (total === 1) {
-        return `1 résultat`;
+        return <span>1 résultat <i class="text-muted">{info}</i></span>;
       }
-      return `${total} résultats`;
+      return <span>{total} résultats. <i class="text-muted">{info}</i></span>;
     }}
     onNoResults="Aucun résultat trouvé."
     loader="Préparation de l'affichage des résultats..."


### PR DESCRIPTION
Comme on ne peut pas facilement savoir comment sont paramétré les facettes dans un sous composant (cf nos discussions), j'affiche le message tout le temps.