### PR TITLE
scroll to top

### DIFF
--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { withRouter } from "react-router";
+
+class ScrollToTop extends React.Component {
+  componentDidUpdate(prevProps) {
+    if (this.props.location.pathname !== prevProps.location.pathname) {
+      window.scrollTo(0, 0);
+    }
+  }
+  render() {
+    return null;
+  }
+}
+
+export default withRouter(ScrollToTop);

--- a/src/router.js
+++ b/src/router.js
@@ -13,6 +13,8 @@ import Notice from './scenes/notice';
 
 import PiwikReactRouter from 'piwik-react-router';
 
+import ScrollToTop from "./components/ScrollToTop";
+
 const piwik = PiwikReactRouter({
 	url: 'https://stats.data.gouv.fr',
 	siteId: 63
@@ -28,6 +30,7 @@ export default class PublicRoutes extends React.Component {
     return (
       <ConnectedRouter history={piwik.connectToHistory(this.props.history)}>
         <div className='main'>
+          <ScrollToTop />
           <Header />
           <Switch>
             <Route exact path={'/'} component={Home} />


### PR DESCRIPTION
Pour fixer ce ticket : https://trello.com/c/MF8IlqYI/213-parfois-lorsque-lon-ouvre-la-recherche-en-diff-en-venant-de-la-page-daccueil-on-commence-en-bas-de-page-et-et-ca-scroll-tout-seu

Source : https://github.com/ReactTraining/react-router/blob/master/packages/react-router-dom/docs/guides/scroll-restoration.md