### PR TITLE
redirect before index

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -7,9 +7,6 @@ const port = 8081;
 
 console.log("START", new Date());
 
-app.use(express.static(path.join(__dirname, "/../../build")));
-app.use(express.static(path.join(__dirname, "/../../sitemap")));
-
 app.use(
   forceDomain({
     hostname: "www.pop.culture.gouv.fr",
@@ -17,6 +14,9 @@ app.use(
     // For later add: `protocol: 'https'`
   })
 );
+
+app.use(express.static(path.join(__dirname, "/../../build")));
+app.use(express.static(path.join(__dirname, "/../../sitemap")));
 
 // Sitemap redirection
 app.get("/sitemap/*", (req, res) => {


### PR DESCRIPTION
D'après mes tests, l'index était généré (et renvoyé) avant la redirection à cause de cette ligne:

```
app.use(express.static(path.join(__dirname, "/../../build")));
```

Ce qui explique que la redirection vers `www` n'avait pas lieu depuis l'index. Ticket : https://trello.com/c/JReTRx3w/85-301-redirect