### PR TITLE
add museofile page

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -12,7 +12,8 @@ import Helmet from "./components/Helmet";
 import Home from "./scenes/home";
 import Search from "./scenes/search";
 import Opendata from "./scenes/opendata";
-import Notice from "./scenes/notice";
+import Notice from "./scenes/notice"
+import Museo from "./scenes/museo"
 
 import ScrollToTop from "./components/ScrollToTop";
 
@@ -42,6 +43,7 @@ export default class PublicRoutes extends React.Component {
               <Route path={"/search"} component={Search} />
               <Route exact path={"/opendata"} component={Opendata} />
               <Route path={"/notice/:ref"} component={Notice} />
+              <Route path={"/museo/:ref"} component={Museo} />
               <Route component={NotFound} />
             </Switch>
           </ErrorBoundary>

--- a/src/scenes/museo/index.css
+++ b/src/scenes/museo/index.css
@@ -1,0 +1,19 @@
+.museo {
+  padding: 15px;
+  margin: 50px auto;
+  max-width: 800px;
+}
+.museo h1 {
+  color: #025d59;
+  font-size: 24px;
+  margin-bottom: 20px;
+}
+.museo dl > dt {
+  color: #025d59;
+  margin-top: 15px;
+}
+
+.museo-map {
+  margin-bottom: 25px;
+  margin-top: 25px;
+}

--- a/src/scenes/museo/index.css
+++ b/src/scenes/museo/index.css
@@ -1,8 +1,18 @@
 .museo {
-  padding: 15px;
   margin: 50px auto;
   max-width: 800px;
+  padding: 30px 25px 30px 25px;
+  margin-bottom: 100px;
 }
+
+@media screen and (min-width: 800px) {
+  .museo {
+    background-color: #fff;
+    border-radius: 5px;
+    box-shadow: 0 2px 4px 1px rgba(189, 189, 189, 0.7);
+  }
+}
+
 .museo h1 {
   color: #025d59;
   font-size: 24px;
@@ -14,6 +24,5 @@
 }
 
 .museo-map {
-  margin-bottom: 25px;
   margin-top: 25px;
 }

--- a/src/scenes/museo/index.js
+++ b/src/scenes/museo/index.js
@@ -1,0 +1,115 @@
+import React from "react";
+import Helmet from "../../components/Helmet";
+import API from "../../services/api";
+import { Mapping } from "pop-shared";
+import Loader from "../../components/loader";
+import Map from "../notice/components/map";
+import "./index.css";
+
+class Museo extends React.Component {
+  state = {
+    museo: null
+  };
+
+  componentDidMount() {
+    const { match } = this.props;
+    this.getApiMuseo(match.params.ref);
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (
+      this.props.match &&
+      this.props.match.params.ref !== newProps.match.params.ref
+    ) {
+      this.getApiMuseo(newProps.match.params.ref);
+    }
+  }
+
+  // Load museo from API.
+  async getApiMuseo(ref) {
+    this.setState({
+      museo: await API.getMuseo(ref)
+    });
+  }
+
+  // Display property label.
+  label = k => {
+    if (Mapping.museo[k]) {
+      return Mapping.museo[k].label || Mapping.museo[k].description || k;
+    }
+    return k;
+  };
+
+  // Transform sh*ty text to readable text.
+  text = (key, val) => {
+    if (key === "URL_M") {
+      const link = val.indexOf("://") === -1 ? "http://" + val : val;
+      return (
+        <a href={link} target="_blank">
+          {val}
+        </a>
+      );
+    } else if (val.match(/#/)) {
+      const list = val.split("#").map(v => <li>{this.removeUglyChars(v)}</li>);
+      return <ul>{list}</ul>;
+    }
+    return this.removeUglyChars(val);
+  };
+
+  // Remove HTML entities and other pollution.
+  removeUglyChars = text => {
+    return text
+      .replace(/&amp;lt;(?:\/?)(?:b|i)&amp;gt;/g, "")
+      .replace(/^ -/, "")
+      .replace(/&quot;/g, '"')
+      .replace(
+        /&amp;lt;A HREF.*?&amp;gt;Joconde&amp;lt;\/A&amp;gt;/g,
+        "Joconde"
+      );
+  };
+
+  // Render all properties.
+  renderProperties = museo => {
+    const dl = Object.entries(museo)
+      .filter(([_key, val]) => val)
+      .filter(([key, _val]) => !["_id", "location", "VIDEO"].includes(key))
+      .map(([key, val]) => {
+        return (
+          <React.Fragment key={key}>
+            <dt>{this.label(key)}</dt>
+            <dd>{this.text(key, val)}</dd>
+          </React.Fragment>
+        );
+      });
+    return <dl>{dl}</dl>;
+  };
+
+  renderMap(loc) {
+    if (!loc) {
+      return <div />;
+    }
+    return <Map notice={{ POP_COORDONNEES: { lat: loc.lat, lon: loc.lon } }} />;
+  }
+
+  // The main render function.
+  render() {
+    const { museo } = this.state;
+    if (!museo) {
+      return <Loader />;
+    }
+    const title = museo.NOMUSAGE || museo.NOMOFF || museo.ANC;
+    return (
+      <div className="museo">
+        <Helmet
+          title={`${title} - POP`}
+          description="À propos de la Plateforme Ouverte du Patrimoine POP."
+        />
+        <h1>{title}</h1>
+        {this.renderProperties(museo)}
+        <div className="museo-map">{this.renderMap(museo.location)}</div>
+      </div>
+    );
+  }
+}
+
+export default Museo;

--- a/src/scenes/notice/joconde.js
+++ b/src/scenes/notice/joconde.js
@@ -402,17 +402,10 @@ const SeeMore = ({ notice }) => {
   if (notice.MUSEO) {
     arr.push(
       <p className="field" key={`notice.MUSEO`}>
-        Lien vers la base MUSEOFILE :
-        <span style={{ width: "100%" }}>
-          <a
-            href={`http://www2.culture.gouv.fr/public/mistral/museo_fr?ACTION=CHERCHER&FIELD_98=REF&VALUE_98=${
-              notice.MUSEO
-            }`}
-            target="_blank"
-          >
-            {notice.MUSEO}
-          </a>
-        </span>
+        Fiche musée :{" "}
+        <a href={`/museo/${notice.MUSEO}`}>
+          {notice.MUSEO}
+        </a>
       </p>
     );
   }

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -16,6 +16,10 @@ class api {
     });
   }
 
+  getMuseo(ref) {
+    return this._get(`${api_url}/museo/${ref}`);
+  }
+
   _get(url) {
     return new Promise((resolve, reject) => {
       fetch(url)


### PR DESCRIPTION
Premire étape pour rappatrier Museofile chez nous. En gros cette PR fait qu'on n'est plus envoyé vers mistral, on reste sur notre site

![notice](https://user-images.githubusercontent.com/1575946/50640924-a9b80100-0f66-11e9-9fc6-67949f9d9e68.gif)

Dans le détail : 
 - Actuellement ça affiche le nom de colonne en brut, **mais** le système est déjà codé pour afficher le label ou la description (next itération : faire la doc côté API).
 - Cette PR doit être mergée après https://github.com/betagouv/pop-api/pull/52 (sinon ça va planter) donc j'attends ta validation @goffle 
 - Il y a quelques transformation de texte vite fait (KISS, je me prend pas la tête avec la base de données, en trois regex c'est plié pour faire un affichage correct).
 - J'utilise la map des notices pour pas refaire un composant. peut-être qu'il faudra _généraliser_ le composant map, pour qu'il soit moins lié aux notices.
 - Peu d'efforts sur le CSS je considère que ça fait le job.
 - Le GIF que j'ai généré clignote, mais en vrai il clignote pas